### PR TITLE
trowel: stack size determines choosing weight

### DIFF
--- a/src/main/java/dev/tizu/boykisserutils/tweaks/TrowelTweak.java
+++ b/src/main/java/dev/tizu/boykisserutils/tweaks/TrowelTweak.java
@@ -22,7 +22,7 @@ public class TrowelTweak implements Listener {
         for (int i = 0; i < 9; i++) {
             var item = player.getInventory().getItem(i);
             if (item != null && item.getType().isBlock())
-				for (int j = 0; j < item.getAmount(); j++) slots.add(i);
+                for (int j = 0; j < item.getAmount(); j++) slots.add(i);
         }
         if (slots.size() == 0)
             return;

--- a/src/main/java/dev/tizu/boykisserutils/tweaks/TrowelTweak.java
+++ b/src/main/java/dev/tizu/boykisserutils/tweaks/TrowelTweak.java
@@ -22,7 +22,7 @@ public class TrowelTweak implements Listener {
         for (int i = 0; i < 9; i++) {
             var item = player.getInventory().getItem(i);
             if (item != null && item.getType().isBlock())
-                slots.add(i);
+				for (int j = 0; j < item.getAmount(); j++) slots.add(i);
         }
         if (slots.size() == 0)
             return;


### PR DESCRIPTION
this should be it methinks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the random selection of block items in the hotbar to favor slots with larger stack sizes, making selection more proportional to the number of items in each slot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->